### PR TITLE
fix: fix crash on iOS 16.6

### DIFF
--- a/ios/ScreenGuard.mm
+++ b/ios/ScreenGuard.mm
@@ -71,16 +71,18 @@ static UITextField *textField;
         
     [view addSubview:textField];
     [view sendSubviewToBack:textField];
+
+    [view.layer.superlayer addSublayer:textField.layer];
     
+    if(textField.layer.sublayers.firstObject) {
+      [textField.layer.sublayers.firstObject addSublayer:view.layer];
+    }
+
     [textField.centerXAnchor constraintEqualToAnchor:view.centerXAnchor].active = YES;
     [textField.centerYAnchor constraintEqualToAnchor:view.centerYAnchor].active = YES;
     [textField.widthAnchor constraintEqualToAnchor:view.widthAnchor].active = YES;
     [textField.heightAnchor constraintEqualToAnchor:view.heightAnchor].active = YES;
       
-    [view.layer.superlayer addSublayer:textField.layer];
-    if(textField.layer.sublayers.firstObject) {
-      [textField.layer.sublayers.firstObject addSublayer:view.layer];
-    }
 }
 
 - (void)removeScreenShot {


### PR DESCRIPTION
Fix crash on iOS due to anchor first before adding to view.

`Terminating app due to uncaught exception 'NSGenericException', reason: 'Unable to activate constraint with anchors <NSLayoutYAxisAnchor:0x1c0278700 "ARSCNView:0x10690d7e0.top"> and <NSLayoutYAxisAnchor:0x1c426db40 "UIView:0x106b14e30.top"> because they have no common ancestor. Does the constraint or its anchors reference items in different view hierarchies? That's illegal.'`