### PR TITLE
fix crash issue on android 14(API level 34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ On Android, remember to setup a little bit as you will not receive the backgroun
 +            android:theme="@style/Theme.AppCompat.Translucent"
 +            android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
 +            android:windowSoftInputMode="stateAlwaysVisible|adjustResize"
++            android:exported="false"
 +        />
     </application>
 </manifest>

--- a/android/src/main/java/com/screenguard/ScreenGuardColorActivity.java
+++ b/android/src/main/java/com/screenguard/ScreenGuardColorActivity.java
@@ -8,6 +8,7 @@ import android.content.IntentFilter;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -90,7 +91,11 @@ public class ScreenGuardColorActivity extends ReactActivity  {
         }
         overridePendingTransition(0, 0);
         IntentFilter intentFilter = new IntentFilter(SCREENGUARD_COLOR_ACTIVITY_CLOSE);
-        registerReceiver(closeReceiver, intentFilter, ContextCompat.RECEIVER_NOT_EXPORTED);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            registerReceiver(closeReceiver, intentFilter, ContextCompat.RECEIVER_NOT_EXPORTED);
+        } else {
+            registerReceiver(closeReceiver, intentFilter);
+        }
     }
 
 

--- a/android/src/main/java/com/screenguard/ScreenGuardColorActivity.java
+++ b/android/src/main/java/com/screenguard/ScreenGuardColorActivity.java
@@ -18,6 +18,7 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 
 import com.bumptech.glide.Glide;
 import com.facebook.react.ReactActivity;
@@ -89,7 +90,7 @@ public class ScreenGuardColorActivity extends ReactActivity  {
         }
         overridePendingTransition(0, 0);
         IntentFilter intentFilter = new IntentFilter(SCREENGUARD_COLOR_ACTIVITY_CLOSE);
-        registerReceiver(closeReceiver, intentFilter);
+        registerReceiver(closeReceiver, intentFilter, ContextCompat.RECEIVER_NOT_EXPORTED);
     }
 
 


### PR DESCRIPTION
Hi,
This PR to fix the `java.lang.SecurityException` when calling `ScreenGuardModule.register(...)` or `ScreenGuardModule.registerWithBlurView(...)`

```
react-native: 0.73.x
react-native-screenguard: 1.0.0
Android 14 API level 34
```

Full error:
```
FATAL EXCEPTION: main
Process: com.app.appname, PID: 27892
java.lang.RuntimeException: Unable to start activity ComponentInfo{com.app.appname/com.screenguard.ScreenGuardColorActivity}: java.lang.SecurityException: com.app.appname: One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:4311)
	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:4459)
	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:103)
	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:139)
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:96)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2853)
	at android.os.Handler.dispatchMessage(Handler.java:108)
	at android.os.Looper.loopOnce(Looper.java:226)
	at android.os.Looper.loop(Looper.java:328)
	at android.app.ActivityThread.main(ActivityThread.java:9224)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:586)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1099)
Caused by: java.lang.SecurityException: com.app.appname: One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts
	at android.os.Parcel.createExceptionOrNull(Parcel.java:3071)
	at android.os.Parcel.createException(Parcel.java:3055)
	at android.os.Parcel.readException(Parcel.java:3038)
	at android.os.Parcel.readException(Parcel.java:2980)
	at android.app.IActivityManager$Stub$Proxy.registerReceiverWithFeature(IActivityManager.java:6380)
	at android.app.ContextImpl.registerReceiverInternal(ContextImpl.java:1876)
	at android.app.ContextImpl.registerReceiver(ContextImpl.java:1811)
	at android.app.ContextImpl.registerReceiver(ContextImpl.java:1799)
	at android.content.ContextWrapper.registerReceiver(ContextWrapper.java:755)
	at android.content.ContextWrapper.registerReceiver(ContextWrapper.java:755)
	at com.screenguard.ScreenGuardColorActivity.onCreate(ScreenGuardColorActivity.java:94)
	at android.app.Activity.performCreate(Activity.java:8948)
	at android.app.Activity.performCreate(Activity.java:8912)
	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1456)
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:4287)
	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:4459) 
	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:103) 
	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:139) 
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:96) 
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2853) 
	at android.os.Handler.dispatchMessage(Handler.java:108) 
	at android.os.Looper.loopOnce(Looper.java:226) 
	at android.os.Looper.loop(Looper.java:328) 
	at android.app.ActivityThread.main(ActivityThread.java:9224) 
	at java.lang.reflect.Method.invoke(Native Method) 
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:586) 
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1099)
``` 