### PR TITLE
fix: colorFromHexString failed parsing

### DIFF
--- a/ios/ScreenGuard.mm
+++ b/ios/ScreenGuard.mm
@@ -212,11 +212,21 @@ UIScrollView *scrollView;
 }
 
 - (UIColor *)colorFromHexString:(NSString *)hexString {
+    if (hexString.length != 7 || ![hexString hasPrefix:@"#"]) {
+        // Handle invalid format by returning a default color, e.g., white.
+        return [UIColor whiteColor];
+    }
     unsigned rgbValue = 0;
     NSScanner *scanner = [NSScanner scannerWithString:hexString];
     [scanner setScanLocation:1]; // bypass '#' character
-    [scanner scanHexInt:&rgbValue];
-    return [UIColor colorWithRed:((rgbValue & 0xFF0000) >> 16)/255.0 green:((rgbValue & 0xFF00) >> 8)/255.0 blue:(rgbValue & 0xFF)/255.0 alpha:1.0];
+    if (![scanner scanHexInt:&rgbValue]) {
+        // Return a default color if parsing fails
+        return [UIColor whiteColor];
+    }
+    return [UIColor colorWithRed:((rgbValue & 0xFF0000) >> 16)/255.0
+                           green:((rgbValue & 0xFF00) >> 8)/255.0
+                            blue:(rgbValue & 0xFF)/255.0
+                           alpha:1.0];
 }
 
 - (UIImage *)convertViewToImage:(UIView *)view {


### PR DESCRIPTION
- React Native: v.0.76.0
- OS: iOS 18.0

Crash:
`Application threw exception NSRangeException: *** -[NSConcreteScanner setScanLocation:]: Index 1 out of bounds; string length 0
Originated at or in a subcall of`

For now, we have applied the fix with patch-package.

Thank you for checking it @gbumps 