### PR TITLE
Fix the syntax error

### DIFF
--- a/react-native-screenguard.podspec
+++ b/react-native-screenguard.podspec
@@ -36,4 +36,5 @@ Pod::Spec.new do |s|
       s.dependency "RCTTypeSafety"
       s.dependency "ReactCommon/turbomodule/core"
     end
+  end
 end


### PR DESCRIPTION
While pod install we catch this error: syntax error, unexpected end-of-input, expecting `end' or dummy end.
So we just need to add one more end.