### PR TITLE
Show screenshot block toast only when overlay is active (android)

### DIFF
--- a/android/src/main/java/com/screenguard/ScreenGuardModule.java
+++ b/android/src/main/java/com/screenguard/ScreenGuardModule.java
@@ -197,12 +197,14 @@ public class ScreenGuardModule implements LifecycleEventListener {
 
                         logAction(ScreenGuardConstants.ACTION_SCREENSHOT_TAKEN, true);
 
-                        Activity currentActivity = currentReactContext.getCurrentActivity();
-                        if (currentActivity != null) {
-                            currentActivity.runOnUiThread(() -> {
-                                Toast.makeText(currentReactContext, ScreenGuardConstants.MSG_SCREENSHOT_BLOCKED,
-                                        Toast.LENGTH_SHORT).show();
-                            });
+                        if (ScreenGuardOverlay.getInstance().isActivated()) {
+                            Activity currentActivity = currentReactContext.getCurrentActivity();
+                            if (currentActivity != null) {
+                                currentActivity.runOnUiThread(() -> {
+                                    Toast.makeText(currentReactContext, ScreenGuardConstants.MSG_SCREENSHOT_BLOCKED,
+                                            Toast.LENGTH_SHORT).show();
+                                });
+                            }
                         }
                     });
         }


### PR DESCRIPTION
This pull request introduces an enhancement to the screenshot event handling logic in `ScreenGuardModule.java`. The most notable change is the addition of a conditional check to ensure that a toast notification is only shown when the screen guard overlay is active.

Screenshot blocking logic improvements:

* Added a check to display the screenshot blocked toast notification only if `ScreenGuardOverlay` is activated, preventing unnecessary notifications when the overlay is not active. (`android/src/main/java/com/screenguard/ScreenGuardModule.java`)